### PR TITLE
Make GLEW optional

### DIFF
--- a/EGL/CMakeLists.txt
+++ b/EGL/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+if(WIN32)
+  set(EGL_PLATFORM_SOURCES
+      ${CMAKE_CURRENT_LIST_DIR}/src/egl_windows.c)
+else()
+  if(UNIX AND NOT APPLE)
+    set(EGL_PLATFORM_SOURCES
+        ${CMAKE_CURRENT_LIST_DIR}/src/egl_x11.c)
+  endif()
+endif()
+
+set(EGL_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/src/egl.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/egl_common.c
+    ${EGL_PLATFORM_SOURCES}
+    ${CMAKE_CURRENT_LIST_DIR}/src/egl_internal.h
+    ${CMAKE_CURRENT_LIST_DIR}/include/EGL/egl.h
+    ${CMAKE_CURRENT_LIST_DIR}/include/EGL/egl.h
+    ${CMAKE_CURRENT_LIST_DIR}/include/EGL/eglext.h
+    ${CMAKE_CURRENT_LIST_DIR}/include/EGL/eglplatform.h
+    ${CMAKE_CURRENT_LIST_DIR}/include/KHR/khrplatform.h)
+
+add_library(egl STATIC
+    ${EGL_SOURCES})
+
+target_include_directories(egl PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include)
+

--- a/EGL/CMakeLists.txt
+++ b/EGL/CMakeLists.txt
@@ -27,3 +27,7 @@ add_library(egl STATIC
 target_include_directories(egl PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/include)
 
+option(EGL_NO_GLEW "Do not use GLEW" OFF)
+if(EGL_NO_GLEW)
+  add_definitions(-DEGL_NO_GLEW)
+endif()

--- a/EGL/src/egl_common.c
+++ b/EGL/src/egl_common.c
@@ -27,6 +27,7 @@
 #include "egl_internal.h"
 
 static __thread LocalStorage g_localStorage = {{0, 0, 0}, EGL_SUCCESS, EGL_NONE, 0, EGL_NO_CONTEXT };
+extern void (*glFinishPTR)();
 
 static EGLBoolean _eglInternalInit()
 {
@@ -2322,7 +2323,7 @@ EGLBoolean _eglWaitNative(EGLint engine)
 
 	if (g_localStorage.api == EGL_OPENGL_API)
 	{
-		glFinish();
+		glFinishPTR();
 	}
 
 	return EGL_TRUE;
@@ -2435,7 +2436,7 @@ EGLBoolean _eglWaitClient(void)
 
 	if (g_localStorage.api == EGL_OPENGL_API)
 	{
-		glFinish();
+		glFinishPTR();
 	}
 
 	return EGL_TRUE;

--- a/EGL/src/egl_internal.h
+++ b/EGL/src/egl_internal.h
@@ -38,8 +38,12 @@
 
 #include <windows.h>
 
+#if !defined(EGL_NO_GLEW)
 #include <GL/glew.h>
 #include <GL/wglew.h>
+#else
+#include <wingdi.h>
+#endif  // EGL_NO_GLEW
 
 #define CONTEXT_ATTRIB_LIST_SIZE 13
 
@@ -72,9 +76,12 @@ typedef struct _NativeLocalStorageContainer {
 
 #include <X11/X.h>
 
+#if !defined(EGL_NO_GLEW)
 #include <GL/glew.h>
 #include <GL/glxew.h>
-
+#else
+#include <GL/glx.h>
+#endif  // EGL_NO_GLEW
 #define CONTEXT_ATTRIB_LIST_SIZE 10
 
 typedef struct _NativeSurfaceContainer {

--- a/EGL/src/egl_windows.c
+++ b/EGL/src/egl_windows.c
@@ -156,6 +156,7 @@ EGLBoolean __internalInit(NativeLocalStorageContainer* nativeLocalStorageContain
 		return EGL_FALSE;
 	}
 
+#if !defined(EGL_NO_GLEW)
 	glewExperimental = GL_TRUE;
 	if (glewInit() != GL_NO_ERROR)
 	{
@@ -172,7 +173,7 @@ EGLBoolean __internalInit(NativeLocalStorageContainer* nativeLocalStorageContain
 
 		return EGL_FALSE;
 	}
-
+#endif
 	return EGL_TRUE;
 }
 


### PR DESCRIPTION
I didn't want to pull GLEW into my project, so I changed the code a bit to dynamically load some WGL and GLX entrypoints (also, `glFinish`).

I'm not  a hundred percent sure this is a safe change, so I merely made it optional, but things seem to work so far. 