### PR TITLE
Change WNDCLASS initialization

### DIFF
--- a/EGL/src/egl_windows.c
+++ b/EGL/src/egl_windows.c
@@ -55,7 +55,8 @@ EGLBoolean __internalInit(NativeLocalStorageContainer* nativeLocalStorageContain
 
 	//
 
-    WNDCLASS wc = {};
+    WNDCLASS wc;
+    memset(&wc, 0, sizeof(WNDCLASS));
 
     wc.lpfnWndProc   = __DummyWndProc;
     wc.hInstance     = GetModuleHandle(NULL);


### PR DESCRIPTION
The way it's initialized right now does not compile in Visual Studio 2017.